### PR TITLE
Tweak field names in Compositions

### DIFF
--- a/clusters.cnp.example.org/composition.yaml
+++ b/clusters.cnp.example.org/composition.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
   reclaimPolicy: Delete
-  compositeResource:
+  compositeTypeRef:
     apiVersion: cnp.example.org/v1alpha1
     kind: AllocatedCluster
-  composedResources:
+  resources:
   - base:
       apiVersion: clusters.cnp.example.org/v1alpha1
       kind: EKS

--- a/eks.clusters.cnp.example.org/composition.yaml
+++ b/eks.clusters.cnp.example.org/composition.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
   reclaimPolicy: Delete
-  compositeResource:
+  compositeTypeRef:
     apiVersion: clusters.cnp.example.org/v1alpha1
     kind: EKS
-  composedResources:
+  resources:
   - base:
       apiVersion: network.aws.crossplane.io/v1alpha3
       kind: VPC

--- a/fluentbits.charts.cnp.example.org/composition.yaml
+++ b/fluentbits.charts.cnp.example.org/composition.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
   reclaimPolicy: Delete
-  compositeResource:
+  compositeTypeRef:
     apiVersion: charts.cnp.example.org/v1alpha1
     kind: FluentBit
-  composedResources:
+  resources:
   - base:
       apiVersion: helm.crossplane.io/v1alpha1
       kind: Release


### PR DESCRIPTION
We prefer simply 'resources' to 'composedResources', and worry that 'compositeResource' could be interpreted as the template for a whole resource, rather than an indicator of the compatible composite resource type.
