### PR TITLE
Reintroduce composite resource claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ example might actually consist of a control plane resource, a few node pool
 resources, and a few Helm chart resources. Thus the "Kubernetes cluster" is a
 composite of a control plane, node pools, and Helm charts.
 
-**What is a 'composite resource requirement'? Why does it exist?**
+**What is a 'composite resource claim'? Why does it exist?**
 
 Crossplane is built on the Kubernetes API. Kubernetes API resources may exist at
 one of two scopes - cluster or namespace. The cluster scope is global; cluster
@@ -139,17 +139,16 @@ resources that exist in that VPC.
 In Crossplane all composite resources are cluster scoped, allowing a Kubernetes
 cluster composite resource (for example) to leverage a VPC network composite
 resource without crossing namespace boundaries (which is considered an anti
-pattern in Kubernetes). Composite resources may however support a namespaced
-'composite resource requirement' - a namespaced proxy of the composite resource.
-Creating, updating, or deleting a namespaced requirement creates, updates, or
-deletes a corresponding cluster scoped composite resource. This allows platform
-builders to distinguish global 'supporting infrastructure' that only a platform
-operator should interact with from infrastructure that platform consumers should
-be able to create, update, and delete on-demand. The separation of a composite
-resource from its requirement also decouples their lifecycles; it allows a
-platform operator to pre-provision SQL instances (for example) via Crossplane
-that platform consumers may later claim instantaneously, without waiting up to
-several minutes for the cloud provider to create them.
+pattern in Kubernetes). Platform operators may however offer a namespaced
+'composite resource claim' - a namespaced proxy of the composite resource.
+Creating, updating, or deleting a claim creates, updates, or deletes its
+corresponding cluster scoped composite resource. This allows platform builders
+to distinguish global 'supporting infrastructure' that only a platform operator
+should interact with from the infrastructure they offer to platform consumers.
+The separation of a composite resource from its claim also decouples their
+lifecycles; it allows a platform operator to offer pre-provisioned SQL instances
+(for example) via Crossplane that platform consumers may claim instantaneously,
+without waiting several minutes for the cloud provider to create them.
 
 [Package Manager refactor]: https://github.com/crossplane/crossplane/pull/1616
 [master branch]: https://github.com/crossplane/example-cnp/tree/master

--- a/clusters.cnp.example.org/definition.yaml
+++ b/clusters.cnp.example.org/definition.yaml
@@ -7,13 +7,13 @@ spec:
   defaultCompositionRef:
     name: clusters.cnp.example.org
   # Composite resources are cluster scoped, but each composite resource may
-  # optionally support a namespaced 'composite resource requirement'. A
-  # requirement acts as a proxy for its composite resource - changes made to the
-  # requirement are reflected on the composite resource. A requirement shares
-  # the API group and schema of its corresponding composite resouce, but must
-  # have a different name. Omit the requirement names when defining a composite
-  # resource that should not support a corresponding requirement resource.
-  requirementNames:
+  # optionally offer a namespaced 'composite resource claim'. A claim acts as a
+  # proxy for its composite resource - changes made to the claim are reflected
+  # on the composite resource. A claim shares the API group and schema of its
+  # corresponding composite resouce, but must have a different name. Omit the
+  # claim names when defining a composite resource that should not offer a
+  # corresponding requirement claim.
+  claimNames:
     kind: Cluster
     listKind: ClusterList
     plural: clusters

--- a/clusters.cnp.example.org/definition.yaml
+++ b/clusters.cnp.example.org/definition.yaml
@@ -6,17 +6,14 @@ metadata:
 spec:
   defaultCompositionRef:
     name: clusters.cnp.example.org
-  # This policy is equivalent to the existing InfrastructurePublication. Making
-  # this a field of the InfrastructureDefinition implies that the package author
-  # controls the publication of packaged types; it cannot easily be overridden
-  # without forking/duplicating the package. The options are 'Private' (the
-  # default), or 'Published'.
-  publicationPolicy: Published
-  # Publishing a composite resource defines a namespaced proxy of the composite
-  # resource. The group, version, and schema of this resource is identical to
-  # those of the composite resource but its kind must differ. Conceptually this
-  # is a 'published composite resource', rather than 'a requirement'.
-  publishedNames:
+  # Composite resources are cluster scoped, but each composite resource may
+  # optionally support a namespaced 'composite resource requirement'. A
+  # requirement acts as a proxy for its composite resource - changes made to the
+  # requirement are reflected on the composite resource. A requirement shares
+  # the API group and schema of its corresponding composite resouce, but must
+  # have a different name. Omit the requirement names when defining a composite
+  # resource that should not support a corresponding requirement resource.
+  requirementNames:
     kind: Cluster
     listKind: ClusterList
     plural: clusters


### PR DESCRIPTION
After some consideration I'm fairly convinced that we need a distinct name for this concept - a namespaced proxy for a composite resource. I've added an FAQ with an entry that hopefully provides some context - specifically highlighting that it's not quite as straightforward as 'is it cluster scoped or namespaced'.